### PR TITLE
ENG-57488: Added the retention period to 13 month for cloud watch log group

### DIFF
--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -434,6 +434,24 @@
             "FunctionName" : { "Ref":"CollectLambdaFunction" }
          }
       },
+      "CollectCloudWatchGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "DependsOn": [
+            "CollectLambdaFunction"
+        ],
+        "Properties": {
+            "LogGroupName": {
+                "Fn::Join": [
+                "",
+                [
+                    "/aws/lambda/",
+                    { "Ref": "CollectLambdaFunction" }
+                ]
+            ]
+        },
+        "RetentionInDays": 400
+        }
+      },
       "RegistrationResource": {
          "Type": "Custom::RegistrationResource",
          "DependsOn": [


### PR DESCRIPTION
### Problem Description
 By default, CloudWatch log groups were created with "Never Expire", leading to uncontrolled storage growth and unnecessary costs.

### Solution Description
Use the AWS CloudFormation (CFN) to automate the process and update the retention period to 13 Month while create cloud watch group. 